### PR TITLE
Remove the "utf8 patch".

### DIFF
--- a/seacucumber/backend.py
+++ b/seacucumber/backend.py
@@ -30,7 +30,7 @@ class SESBackend(BaseEmailBackend):
             SendEmailTask.delay(
                 message.from_email,
                 message.recipients(),
-                message.message().as_string().decode('utf8'),
+                message.message().as_string(),
             )
             num_sent += 1
         return num_sent


### PR DESCRIPTION
The patch doesn't really solve the problem since boto does a base64 encode in send_raw_email which in turn does not work with unicode strings containing special characters (öäüá… – at least on py2x).

You can verify that by doing f.e.:

``` python
import base64
base64.b64encode(u'Fööbär')
```

By removing the `decode` (which is used to turn ascii to unicode), we actually support sending unicode strings. I know that sounds crazy but here is an example:

``` python
import base64
base64.b64encode(u'Fööbär'.encode('ascii'))
```

Works without an exception :-) When further debugging we can actually see that boto sets the correct UTF8 header for the mail, so that works flawlessly.

I ran into this while trying to send a german mail (so umlauts included) which in turn was generated (and translated) via django's render_to_string functionality (and i18n ofc).

Removing the patch solved my problem, however it does require that you pass in ASCII strings (so `'Fööbär'.encode('utf8')`) or, as in my case, `django.utils.safestring.SafeUnicode` (as returned by `django.template.loader.render_to_string`).

That whole situation is pretty messed up since boto does not do an `.encode('utf8')` when at boto/ses/connection.py:L281 -.-

Another way to solve this issue would be to do an `isinstance(var, unicode)` check and do the `encode` part before delaying the SendEmailTask. This could be more favorable since it hides an implementation detail. On the other side it's much more implicit then,… Well I guess you will have to decide :-)
