### PR TITLE
Second data point is for the past two weeks

### DIFF
--- a/seacucumber/management/commands/ses_usage.py
+++ b/seacucumber/management/commands/ses_usage.py
@@ -42,11 +42,9 @@ class Command(BaseCommand):
         stats = stats['SendDataPoints']
         
         today = datetime.date.today()
-        yesterday = today - datetime.timedelta(days=1)
         current_day = {'HeaderName': 'Current Day: %s/%s' % (today.month, 
                                                              today.day)}
-        prev_day = {'HeaderName': 'Yesterday: %s/%s' % (yesterday.month,
-                                                        yesterday.day)}
+        prev_day = {'HeaderName': 'Past two weeks'}
         
         for data_point in stats:
             if self._is_data_from_today(data_point):


### PR DESCRIPTION
I don't know if this is always true or not, if the second data point changes over time, but our account is reporting back the past two weeks of usage, which was kind of startling when it said "Yesterday".

Do you know if this is always the case? Maybe Amazon changed their API recently?
