### PR TITLE
Updated to use @celery.task instead of deprecated celery.task base class

### DIFF
--- a/seacucumber/backend.py
+++ b/seacucumber/backend.py
@@ -5,7 +5,7 @@ your settings.py::
     EMAIL_BACKEND = 'seacucumber.backend.SESBackend'
 """
 from django.core.mail.backends.base import BaseEmailBackend
-from seacucumber.tasks import SendEmailTask
+from seacucumber.tasks import send_email
 
 
 class SESBackend(BaseEmailBackend):
@@ -27,7 +27,7 @@ class SESBackend(BaseEmailBackend):
         num_sent = 0
         for message in email_messages:
             # Hand this off to a celery task.
-            SendEmailTask.delay(
+            send_email.delay(
                 message.from_email,
                 message.recipients(),
                 message.message().as_string().decode('utf8'),

--- a/seacucumber/tasks.py
+++ b/seacucumber/tasks.py
@@ -1,28 +1,33 @@
-"""
-Supporting celery tasks go in this module. The primarily interesting one is
-SendEmailTask, which handles sending a single Django EmailMessage object.
-"""
 import logging
+import celery
+from celery import Task
 from django.conf import settings
-from celery.task import Task
 from boto.ses.exceptions import SESAddressBlacklistedError, SESDomainEndsWithDotError
 from seacucumber.util import get_boto_ses_connection
 
 logger = logging.getLogger(__name__)
 
-class SendEmailTask(Task):
+class EmailTask(Task):
     """
-    Sends an email through Boto's SES API module.
+    Base email task that provides a connection that email tasks can reuse.
     """
+    abstract = True
+    _connection = None
+
     def __init__(self):
         self.max_retries = getattr(settings, 'CUCUMBER_MAX_RETRIES', 60)
         self.default_retry_delay = getattr(settings, 'CUCUMBER_RETRY_DELAY', 60)
         self.rate_limit = getattr(settings, 'CUCUMBER_RATE_LIMIT', 1)
-        # A boto.ses.SESConnection object, after running _open_ses_conn().
-        self.connection = None
 
-    def run(self, from_email, recipients, message):
-        """
+    @property
+    def connection(self):
+        if self._connection is None:
+            self._connection = get_boto_ses_connection()
+        return self._connection
+
+@celery.task(base=EmailTask)
+def send_email(from_email, recipients, message):
+    """
         This does the dirty work. Connects to Amazon SES via boto and fires
         off the message.
 
@@ -31,52 +36,41 @@ class SendEmailTask(Task):
         :param list recipients: A list of email addresses to send the
             message to.
         :param str message: The body of the message.
-        """
-        self._open_ses_conn()
-        try:
-            # We use the send_raw_email func here because the Django
-            # EmailMessage object we got these values from constructs all of
-            # the headers and such.
-            self.connection.send_raw_email(
-                source=from_email,
-                destinations=recipients,
-                raw_message=message,
+    """
+    try:
+        # We use the send_raw_email func here because the Django
+        # EmailMessage object we got these values from constructs all of
+        # the headers and such.
+        send_email.connection.send_raw_email(
+            source=from_email,
+            destinations=recipients,
+            raw_message=message,
             )
-        except SESAddressBlacklistedError, exc:
-            # Blacklisted users are those which delivery failed for in the
-            # last 24 hours. They'll eventually be automatically removed from
-            # the blacklist, but for now, this address is marked as
-            # undeliverable to.
-            logger.warning(
-                'Attempted to email a blacklisted user: %s' % recipients,
-                exc_info=exc,
-                extra={'trace': True}
-            )
-            return False
-        except SESDomainEndsWithDotError, exc:
-            # Domains ending in a dot are simply invalid.
-            logger.warning(
-                'Invalid recipient, ending in dot: %s' % recipients,
-                exc_info=exc,
-                extra={'trace': True}
-            )
-            return False
-        except Exception, exc:
-            # Something else happened that we haven't explicitly forbade
-            # retry attempts for.
-            #noinspection PyUnresolvedReferences
-            self.retry(exc=exc)
+    except SESAddressBlacklistedError, exc:
+        # Blacklisted users are those which delivery failed for in the
+        # last 24 hours. They'll eventually be automatically removed from
+        # the blacklist, but for now, this address is marked as
+        # undeliverable to.
+        logger.warning(
+            'Attempted to email a blacklisted user: %s' % recipients,
+            exc_info=exc,
+            extra={'trace': True}
+        )
+        return False
+    except SESDomainEndsWithDotError, exc:
+        # Domains ending in a dot are simply invalid.
+        logger.warning(
+            'Invalid recipient, ending in dot: %s' % recipients,
+            exc_info=exc,
+            extra={'trace': True}
+        )
+        return False
+    except Exception, exc:
+        # Something else happened that we haven't explicitly forbade
+        # retry attempts for.
+        #noinspection PyUnresolvedReferences
+        raise send_email.retry(exc=exc)
 
-        # We shouldn't ever block long enough to see this, but here it is
-        # just in case (for debugging?).
-        return True
-
-    def _open_ses_conn(self):
-        """
-        Create a connection to the AWS API server. This can be reused for
-        sending multiple emails.
-        """
-        if self.connection:
-            return
-
-        self.connection = get_boto_ses_connection()
+    # We shouldn't ever block long enough to see this, but here it is
+    # just in case (for debugging?).
+    return True


### PR DESCRIPTION
Note that CHANGELOG was not updated.
