### PR TITLE
Change SendEmailTask to .apply_async() from a shortcut .delay() to support routing tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,20 @@ check the ``ses_usage`` management command again at a later date after you've
 sent some emails. You'll need to manually bump up your rate settings in
 ``settings.py``.
 
+Routing Tasks
+=============
+If you want to route Sea Cucumber task to different queues.
+
+Add this to setting::
+
+    CUCUMBER_ROUTE_QUEUE = 'YOUR-ROUTE-QUEUE'
+
+Then update the celery configuration for routes. Example celeryconfig.py::
+
+    CELERY_ROUTES = {
+        'seacucumber.tasks.#': {'queue': 'YOUR-ROUTE-QUEUE'},
+    }
+
 DKIM
 ====
 


### PR DESCRIPTION
Celery Task.delay() is always a shortcut to Task.apply_async() and its limited. So i made a changed on it for we to extend our parameters and support routing tasks from different queues.

Celery Routing and Calling Tasks:
http://celery.readthedocs.org/en/latest/userguide/routing.html
http://celery.readthedocs.org/en/latest/userguide/calling.html#calling-cheat
