### PR TITLE
Fixes AttributeError thrown by ses_usage command

### DIFF
--- a/seacucumber/util.py
+++ b/seacucumber/util.py
@@ -3,7 +3,7 @@ Various utility functions.
 """
 
 from django.conf import settings
-import boto
+import boto.ses
 
 # dkim isn't required, but we'll use it if we have it.
 try:


### PR DESCRIPTION
ses_usage management command throws the below error due to an incorrect import

$ ./manage.py  ses_usage
Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/seacucumber/management/commands/ses_usage.py", line 20, in handle
    conn = get_boto_ses_connection()
  File "/home/lijo/.virtualenvs/eshop/local/lib/python2.7/site-packages/seacucumber/util.py", line 40, in get_boto_ses_connection
    return boto.ses.connect_to_region(
AttributeError: 'module' object has no attribute 'ses'