### PR TITLE
3.3.3 - Refresh with boto3, python 3 and django 3 support

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+default_section=THIRDPARTY
+force_grid_wrap=0
+include_trailing_comma=true
+known_first_party=
+    seacucumber
+
+line_length=88
+lines_after_imports=2
+multi_line_output=3
+use_parentheses=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.17
+    hooks:
+      - id: isort
+        language_version: "python3"
+
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        name: black
+        language: system
+        language_version: "python3"
+        entry: black
+        types: [python]
+
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.4.4
+    hooks:
+      - id: pylint
+        language_version: "python3"

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,659 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,setup.cfg,setup.py,rest.log,install.py,requirements.txt,install.sh,Pipfile,README.md,debug.log,docker_dev_oms_init.sh,docker_dev_init.sh,docker_unit_test_entrypoint.sh,install.py,wait_for_db.sh,migrations
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=16
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=abstract-method,
+        access-member-before-definition,
+        anomalous-backslash-in-string,
+        apply-builtin,
+        arguments-differ,
+        assign-to-new-keyword,
+        attribute-defined-outside-init,
+        backtick,
+        bad-continuation,
+        bad-format-character,
+        bad-inline-option,
+        bad-mcs-classmethod-argument,
+        bad-python3-import,
+        bad-super-call,
+        bad-whitespace,
+        basestring-builtin,
+        broad-except,
+        buffer-builtin,
+        c-extension-no-member,
+        cell-var-from-loop,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        comprehension-escape,
+        consider-iterating-dictionary,
+        consider-using-enumerate,
+        consider-using-ternary,
+        dangerous-default-value,
+        delslice-method,
+        deprecated-itertools-function,
+        deprecated-lambda,
+        deprecated-operator-function,
+        deprecated-pragma,
+        deprecated-str-translate-call,
+        deprecated-string-function,
+        deprecated-sys-function,
+        deprecated-types-field,
+        deprecated-urllib-function,
+        dict-items-not-iterating,
+        dict-iter-method,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        dict-view-method,
+        div-method,
+        empty-docstring,
+        eq-without-hash,
+        eval-used,
+        exception-escape,
+        exception-message-attribute,
+        exec-used,
+        execfile-builtin,
+        fatal,
+        file-builtin,
+        file-ignored,
+        filter-builtin-not-iterating,
+        fixme,
+        function-redefined,
+        getslice-method,
+        global-statement,
+        global-variable-undefined,
+        hex-method,
+        idiv-method,
+        import-error,
+        import-star-module-level,
+        inconsistent-return-statements,
+        indexing-exception,
+        input-builtin,
+        intern-builtin,
+        invalid-all-object,
+        invalid-name,
+        invalid-str-codec,
+        invalid-unary-operand-type,
+        invalid-unicode-literal,
+        keyword-arg-before-vararg,
+        len-as-condition,
+        locally-disabled,
+        locally-enabled,
+        logging-not-lazy,
+        logging-too-many-args,
+        long-builtin,
+        long-suffix,
+        lost-exception,
+        map-builtin-not-iterating,
+        metaclass-assignment,
+        method-hidden,
+        misplaced-bare-raise,
+        misplaced-comparison-constant,
+        missing-docstring,
+        multiple-imports,
+        multiple-statements,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        no-else-return,
+        no-init,
+        no-member,
+        no-method-argument,
+        no-name-in-module,
+        no-self-argument,
+        no-self-use,
+        no-value-for-parameter,
+        non-ascii-bytes-literal,
+        nonzero-method,
+        not-an-iterable,
+        not-callable,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        old-style-class,
+        parameter-unpacking,
+        pointless-statement,
+        pointless-string-statement,
+        property-on-old-class,
+        protected-access,
+        raising-bad-type,
+        raising-format-tuple,
+        raising-string,
+        range-builtin-not-iterating,
+        raw-checker-failed,
+        raw_input-builtin,
+        rdiv-method,
+        redefined-argument-from-local,
+        redefined-builtin,
+        redefined-outer-name,
+        reduce-builtin,
+        redundant-unittest-assert,
+        reimported,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        simplifiable-if-statement,
+        single-string-used-for-slots,
+        singleton-comparison,
+        standarderror-builtin,
+        super-init-not-called,
+        superfluous-parens,
+        suppressed-message,
+        sys-max-int,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-format-args,
+        too-many-instance-attributes,
+        too-many-lines,
+        too-many-locals,
+        too-many-nested-blocks,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        undefined-loop-variable,
+        undefined-variable,
+        unexpected-keyword-arg,
+        unexpected-special-method-signature,
+        ungrouped-imports,
+        unichr-builtin,
+        unicode-builtin,
+        unidiomatic-typecheck,
+        unpacking-in-except,
+        unreachable,
+        unsubscriptable-object,
+        unsupported-membership-test,
+        unused-argument,
+        unused-format-string-argument,
+        unused-wildcard-import,
+        useless-else-on-loop,
+        useless-suppression,
+        using-cmp-argument,
+        using-constant-test,
+        wrong-import-order,
+        wrong-import-position,
+        xrange-builtin,
+        xreadlines-attribute,
+        zip-builtin-not-iterating,
+        useless-object-inheritance,
+        missing-super-argument
+
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=bad-indentation,
+        bare-except,
+        line-too-long,
+        logging-format-interpolation,
+        print-statement,
+        relative-import,
+        trailing-newlines,
+        trailing-whitespace,
+        unused-import,
+        unused-variable,
+        wildcard-import
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 Sea Cucumber Change Log
 
+1.6.1
+=====
+
+* Migrate to boto3
+
 1.5.2
 =====
 

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ Sea Cucumber Change Log
 =====
 
 * Migrate to boto3
+* Added support for Django 1.7 through Django 3
+* Added support for Python 3
+* Added pre-commit hooks for code quality and linting
 
 1.5.2
 =====

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==================
-Sea Cucumber 1.5.1
+Sea Cucumber 1.6.1
 ==================
 :Info: A Django email backend for Amazon Simple Email Service, backed by django-celery_
 :Author: DUO Interactive, LLC
@@ -23,12 +23,12 @@ time-consuming. Sending emails with Sea Cucumber might be attractive to you if:
 * You don't want to have to worry about PTR records, Reverse DNS, email
   whitelist/blacklist services.
 * You are already deployed on EC2 (In-bound traffic to SES is free from EC2
-  instances). This is not a big deal either way, but is an additional perk if 
+  instances). This is not a big deal either way, but is an additional perk if
   you happen to be on AWS.
 
 Installation
 ============
-Assuming you've got Django_ and django-celery_ installed, you'll need 
+Assuming you've got Django_ and django-celery_ installed, you'll need
 Boto_ 2.0b4 or higher. boto_ is a Python library that wraps the AWS API.
 
 You can do the following to install boto_ 2.0b4 (we're using --upgrade here to
@@ -43,7 +43,7 @@ Install Sea Cucumber::
 Add the following to your settings.py::
 
     EMAIL_BACKEND = 'seacucumber.backend.SESBackend'
-    
+
     # These are optional -- if they're set as environment variables they won't
     # need to be set here as well
     AWS_SES_REGION_NAME = 'YOUR-REGION'  # Default is us-east-1
@@ -61,13 +61,13 @@ The region name is optional but keep in mind addresses are linked to a specific 
 Email Address Verification
 ==========================
 
-Before you can send email 'from' an email address through SES, you must first 
+Before you can send email 'from' an email address through SES, you must first
 verify your ownership of it::
 
 	./manage.py ses_address verify batman@gotham.gov
 
 After you've run the verification above you will need to check the email
-account's inbox (from your mail client or provider's web interface) and click 
+account's inbox (from your mail client or provider's web interface) and click
 the authorization link in the email Amazon sends you. After that, your address
 is ready to go.
 
@@ -79,7 +79,7 @@ To remove a previously verified address::
 
 	./manage.py ses_address delete batman@gotham.gov
 
-Now, when you use ``django.core.mail.send_mail`` from a verified email address, 
+Now, when you use ``django.core.mail.send_mail`` from a verified email address,
 Sea Cucumber will handle message delivery.
 
 Rate Limiting
@@ -88,26 +88,26 @@ Rate Limiting
 If you are a new SES user, your default quota will be 1,000 emails per 24
 hour period at a maximum rate of one email per second. Sea Cucumber defaults
 to enforcing the one email per second at the celery level, but you must not
-have disabled celery rate limiting. 
+have disabled celery rate limiting.
 
 If you have this::
 
     CELERY_DISABLE_RATE_LIMITS = True
-    
+
 Change it to this::
 
     CELERY_DISABLE_RATE_LIMITS = False
-    
+
 Then check your SES max rate by running::
 
     ./manage.py ses_usage
-    
+
 If your rate limit is more than ``1.0/sec``, you'll need to set that numeric
 value in your ``CUCUMBER_RATE_LIMIT`` setting like so::
 
     # Rate limit to three outgoing SES emails a second.
     CUCUMBER_RATE_LIMIT = 3
-    
+
 Failure to follow the rate limits may result in BotoServerError exceptions
 being raised, which makes celery unhappy.
 
@@ -137,14 +137,14 @@ Using DomainKeys_ is entirely optional, however it is recommended by Amazon for
 authenticating your email address and improving delivery success rate.  See
 http://docs.amazonwebservices.com/ses/latest/DeveloperGuide/DKIM.html.
 Besides authentication, you might also want to consider using DKIM in order to
-remove the `via email-bounces.amazonses.com` message shown to gmail users - 
+remove the `via email-bounces.amazonses.com` message shown to gmail users -
 see http://support.google.com/mail/bin/answer.py?hl=en&answer=1311182.
 
 To enable DKIM signing you should install the pydkim_ package and specify values
 for the ``DKIM_PRIVATE_KEY`` and ``DKIM_DOMAIN`` settings.  You can generate a
 private key with a command such as ``openssl genrsa 1024`` and get the public key
 portion with ``openssl rsa -pubout <private.key``.  The public key should be
-published to ``ses._domainkey.example.com`` if your domain is example.com.  You 
+published to ``ses._domainkey.example.com`` if your domain is example.com.  You
 can use a different name instead of ``ses`` by changing the ``DKIM_SELECTOR``
 setting.
 

--- a/seacucumber/__init__.py
+++ b/seacucumber/__init__.py
@@ -1,7 +1,7 @@
 """
-Sea Cucumber is a Django email backend for Amazon Simple Email Service, 
+Sea Cucumber is a Django email backend for Amazon Simple Email Service,
 backed by celery. The interesting bits are in backend.py and tasks.py. The
-rest of the contents of this module are largely optional. 
+rest of the contents of this module are largely optional.
 """
 # In the form of Major, Minor.
-VERSION = (1, 5, 2)
+VERSION = (1, 6, 1)

--- a/seacucumber/backend.py
+++ b/seacucumber/backend.py
@@ -8,7 +8,7 @@ your settings.py::
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 
-from seacucumber.tasks import SendEmailTask
+from seacucumber.tasks import send_email_task
 
 
 class SESBackend(BaseEmailBackend):
@@ -33,7 +33,7 @@ class SESBackend(BaseEmailBackend):
         num_sent = 0
         for message in email_messages:
             # Hand this off to a celery task.
-            SendEmailTask.apply_async(
+            send_email_task.apply_async(
                 args=[
                     message.from_email,
                     message.recipients(),

--- a/seacucumber/backend.py
+++ b/seacucumber/backend.py
@@ -7,6 +7,7 @@ your settings.py::
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
+
 from seacucumber.tasks import SendEmailTask
 
 
@@ -28,14 +29,16 @@ class SESBackend(BaseEmailBackend):
             guarantee delivery just yet.
         """
 
-        queue = getattr(settings, 'CUCUMBER_ROUTE_QUEUE', '')
+        queue = getattr(settings, "CUCUMBER_ROUTE_QUEUE", "")
         num_sent = 0
         for message in email_messages:
             # Hand this off to a celery task.
-            SendEmailTask.apply_async(args=[
+            SendEmailTask.apply_async(
+                args=[
                     message.from_email,
                     message.recipients(),
-                    message.message().as_string().decode('utf8'),], 
+                    message.message().as_string(),
+                ],
                 queue=queue,
             )
             num_sent += 1

--- a/seacucumber/management/commands/ses_address.py
+++ b/seacucumber/management/commands/ses_address.py
@@ -30,13 +30,16 @@ class Command(BaseCommand):
     # <action> must be one of the following.
     valid_actions = ["verify", "list", "delete"]
 
+    def add_arguments(self, parser):
+        # Kept the argument name args to be compatible with django 1.6+
+        parser.add_argument("args", nargs="+", type=str)
+
     def handle(self, *args, **options):
         """
         Parses/validates, and breaks off into actions.
         """
         if len(args) < 1:
             raise CommandError("Please specify an action. See --help.")
-
         action = args[0]
         email = None
 
@@ -70,10 +73,10 @@ class Command(BaseCommand):
         """
         client = get_boto_ses_client()
         if action == "verify":
-            client.verify_email_address(email)
+            client.verify_email_address(EmailAddress=email)
             print("A verification email has been sent to %s." % email)
         elif action == "delete":
-            client.delete_verified_email_address(email)
+            client.delete_verified_email_address(EmailAddress=email)
             print("You have deleted %s from your SES account." % email)
         elif action == "list":
             verified_result = client.list_verified_email_addresses()

--- a/seacucumber/management/commands/ses_address.py
+++ b/seacucumber/management/commands/ses_address.py
@@ -1,10 +1,12 @@
 """
 Handles management of SES email addresses.
 """
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 from django.core.validators import validate_email
-from django.core.exceptions import ValidationError
-from seacucumber.util import get_boto_ses_connection
+
+from seacucumber.util import get_boto_ses_client
+
 
 class Command(BaseCommand):
     """
@@ -12,18 +14,21 @@ class Command(BaseCommand):
     email addresses. Make sure to have 'seacucumber' in INSTALLED_APPS, or this
     won't be available.
     """
+
     args = "<action> [<email address>]"
-    help = "Manages SES emails. <action> may be one of the following:\n"\
-           "  verify <email>   Sends a verification request for an address.\n"\
-           "  list             Lists all fully verified addresses.\n"\
-           "  delete <email>   Deletes an address from your SES account.\n\n"\
-           "Examples:\n"\
-           "  ./manage.py ses_address verify some@addres.com\n"\
-           "  ./manage.py ses_address list\n"\
-           "  ./manage.py ses_address delete some@address.com"
+    help = (
+        "Manages SES emails. <action> may be one of the following:\n"
+        "  verify <email>   Sends a verification request for an address.\n"
+        "  list             Lists all fully verified addresses.\n"
+        "  delete <email>   Deletes an address from your SES account.\n\n"
+        "Examples:\n"
+        "  ./manage.py ses_address verify some@addres.com\n"
+        "  ./manage.py ses_address list\n"
+        "  ./manage.py ses_address delete some@address.com"
+    )
 
     # <action> must be one of the following.
-    valid_actions = ['verify', 'list', 'delete']
+    valid_actions = ["verify", "list", "delete"]
 
     def handle(self, *args, **options):
         """
@@ -39,7 +44,7 @@ class Command(BaseCommand):
             message = "Invalid action: %s" % action
             raise CommandError(message)
 
-        if action in ['verify', 'delete']:
+        if action in ["verify", "delete"]:
             if len(args) < 2:
                 message = "Please specify an email address to %s." % action
                 raise CommandError(message)
@@ -63,35 +68,24 @@ class Command(BaseCommand):
         :param email: Either an email address, or None if the action doesn't
             need an email address.
         """
-        connection = self._get_ses_connection()
+        client = get_boto_ses_client()
         if action == "verify":
-            connection.verify_email_address(email)
+            client.verify_email_address(email)
             print("A verification email has been sent to %s." % email)
         elif action == "delete":
-            connection.delete_verified_email_address(email)
+            client.delete_verified_email_address(email)
             print("You have deleted %s from your SES account." % email)
         elif action == "list":
-            verified_result = connection.list_verified_email_addresses()
-            if len(verified_result.VerifiedEmailAddresses) > 0:
-                print("The following emails have been fully verified on your "\
-                      "Amazon SES account:")
-                for vemail in verified_result.VerifiedEmailAddresses:
-                    print ("  %s" % vemail)
+            verified_result = client.list_verified_email_addresses()
+            if len(verified_result.get("VerifiedEmailAddresses", [])) > 0:
+                print(
+                    "The following emails have been fully verified on your "
+                    "Amazon SES account:"
+                )
+                for vemail in verified_result.get("VerifiedEmailAddresses"):
+                    print("  %s" % vemail)
             else:
                 print("Your account has no fully verified email addresses yet.")
-
-    def _get_ses_connection(self):
-        """
-        Convenience method for returning a SES connection, and handling any
-        errors that may appear.
-
-        :rtype: boto.ses.SESConnection
-        """
-        try:
-            connection = get_boto_ses_connection()
-            return connection
-        except:
-            raise Exception("Could not connect to Amazon SES service")
 
     def _is_valid_email(self, email):
         """

--- a/seacucumber/management/commands/ses_usage.py
+++ b/seacucumber/management/commands/ses_usage.py
@@ -2,13 +2,17 @@
 Shows some usage levels and limits for the last and previous 24 hours.
 """
 import datetime
+
 from django.core.management.base import BaseCommand
-from seacucumber.util import get_boto_ses_connection
+
+from seacucumber.util import get_boto_ses_client
+
 
 class Command(BaseCommand):
     """
     This command shows some really vague usage and quota stats from SES.
     """
+
     help = "Shows SES usage and quota limits."
 
     def handle(self, *args, **options):
@@ -17,74 +21,55 @@ class Command(BaseCommand):
         dirty work.
         """
         # AWS SES connection, which can be re-used for each query needed.
-        conn = get_boto_ses_connection()
-        self._print_quota(conn)
-        self._print_daily_stats(conn)
-           
-    def _print_quota(self, conn):
+        client = get_boto_ses_client()
+        self._print_quota(client)
+        self._print_daily_stats(client)
+
+    def _print_quota(self, client):
         """
         Prints some basic quota statistics.
         """
-        quota = conn.get_send_quota()
-        quota = quota['GetSendQuotaResponse']['GetSendQuotaResult']
-        
-        print "--- SES Quota ---"
-        print "  24 Hour Quota: %s" % quota['Max24HourSend']
-        print "  Sent (Last 24 hours): %s" % quota['SentLast24Hours']
-        print "  Max sending rate: %s/sec" % quota['MaxSendRate']
-        
-    def _print_daily_stats(self, conn):
+        quota = client.get_send_quota()
+
+        print("--- SES Quota ---")
+        print("  24 Hour Quota: %s" % quota["Max24HourSend"])
+        print("  Sent (Last 24 hours): %s" % quota["SentLast24Hours"])
+        print("  Max sending rate: %s/sec" % quota["MaxSendRate"])
+
+    def _print_daily_stats(self, client):
         """
         Prints a Today/Last 24 hour stats section.
         """
-        stats = conn.get_send_statistics()
-        stats = stats['GetSendStatisticsResponse']['GetSendStatisticsResult']
-        stats = stats['SendDataPoints']
-        
+        stats = client.get_send_statistics()
+        stats = stats["SendDataPoints"]
+
         today = datetime.date.today()
-        current_day = {'HeaderName': 'Current Day: %s/%s' % (today.month, 
-                                                             today.day)}
-        prev_day = {'HeaderName': 'Past two weeks'}
-        
+        current_day = {"HeaderName": "Current Day: %s/%s" % (today.month, today.day)}
+        prev_day = {"HeaderName": "Past two weeks"}
+
         for data_point in stats:
-            if self._is_data_from_today(data_point):
+            if data_point.get("Timestamp").date() == today:
                 day_dict = current_day
             else:
                 day_dict = prev_day
-                
-            self._update_day_dict(data_point, day_dict)      
+
+            self._update_day_dict(data_point, day_dict)
 
         for day in [current_day, prev_day]:
-            print "--- %s ---" % day.get('HeaderName', 0)
-            print "  Delivery attempts: %s" % day.get('DeliveryAttempts', 0)
-            print "  Bounces: %s" % day.get('Bounces', 0)
-            print "  Rejects: %s" % day.get('Rejects', 0)
-            print "  Complaints: %s" % day.get('Complaints', 0)
-        
-    def _is_data_from_today(self, data_point):
-        """
-        Takes a DataPoint from SESConnection.get_send_statistics() and returns
-        True if it is talking about the current date, False if not.
-        
-        :param dict data_point: The data point to consider.
-        :rtype: bool
-        :returns: True if this data_point is for today, False if not (probably
-            yesterday).
-        """
-        today = datetime.date.today()
-        
-        raw_timestr = data_point['Timestamp']
-        dtime = datetime.datetime.strptime(raw_timestr, '%Y-%m-%dT%H:%M:%SZ')
-        return today.day == dtime.day
-    
+            print("--- %s ---" % day.get("HeaderName", 0))
+            print("  Delivery attempts: %s" % day.get("DeliveryAttempts", 0))
+            print("  Bounces: %s" % day.get("Bounces", 0))
+            print("  Rejects: %s" % day.get("Rejects", 0))
+            print("  Complaints: %s" % day.get("Complaints", 0))
+
     def _update_day_dict(self, data_point, day_dict):
         """
         Helper method for :meth:`_print_daily_stats`. Given a data point and
         the correct day dict, update attribs on the dict with the contents
         of the data point.
-        
+
         :param dict data_point: The data point to add to the day's stats dict.
         :param dict day_dict: A stats-tracking dict for a 24 hour period.
         """
-        for topic in ['Bounces', 'Complaints', 'DeliveryAttempts', 'Rejects']:
+        for topic in ["Bounces", "Complaints", "DeliveryAttempts", "Rejects"]:
             day_dict[topic] = day_dict.get(topic, 0) + int(data_point[topic])

--- a/seacucumber/tasks.py
+++ b/seacucumber/tasks.py
@@ -5,7 +5,7 @@ SendEmailTask, which handles sending a single Django EmailMessage object.
 
 import logging
 
-from celery.task import Task
+from celery import Task
 from django.conf import settings
 
 from seacucumber.util import dkim_sign, get_boto_ses_client

--- a/seacucumber/tasks.py
+++ b/seacucumber/tasks.py
@@ -5,11 +5,11 @@ SendEmailTask, which handles sending a single Django EmailMessage object.
 
 import logging
 
-from django.conf import settings
 from celery.task import Task
-from boto.ses.exceptions import SESAddressBlacklistedError, SESDomainEndsWithDotError, SESLocalAddressCharacterError, SESIllegalAddressError
+from django.conf import settings
 
-from seacucumber.util import get_boto_ses_connection, dkim_sign
+from seacucumber.util import dkim_sign, get_boto_ses_client
+
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +18,13 @@ class SendEmailTask(Task):
     """
     Sends an email through Boto's SES API module.
     """
+
     def __init__(self):
-        self.max_retries = getattr(settings, 'CUCUMBER_MAX_RETRIES', 60)
-        self.default_retry_delay = getattr(settings, 'CUCUMBER_RETRY_DELAY', 60)
-        self.rate_limit = getattr(settings, 'CUCUMBER_RATE_LIMIT', 1)
-        # A boto.ses.SESConnection object, after running _open_ses_conn().
-        self.connection = None
+        self.max_retries = getattr(settings, "CUCUMBER_MAX_RETRIES", 60)
+        self.default_retry_delay = getattr(settings, "CUCUMBER_RETRY_DELAY", 60)
+        self.rate_limit = getattr(settings, "CUCUMBER_RATE_LIMIT", 1)
+
+        self._client = None
 
     def run(self, from_email, recipients, message):
         """
@@ -36,74 +37,56 @@ class SendEmailTask(Task):
             message to.
         :param str message: The body of the message.
         """
-        self._open_ses_conn()
+        client = self._get_boto_ses_client()
         try:
             # We use the send_raw_email func here because the Django
             # EmailMessage object we got these values from constructs all of
             # the headers and such.
-            self.connection.send_raw_email(
-                source=from_email,
-                destinations=recipients,
-                raw_message=dkim_sign(message),
+            client.send_raw_email(
+                Source=from_email,
+                Destinations=recipients,
+                RawMessage={"Data": dkim_sign(message)},
             )
-        except SESAddressBlacklistedError, exc:
-            # Blacklisted users are those which delivery failed for in the
-            # last 24 hours. They'll eventually be automatically removed from
-            # the blacklist, but for now, this address is marked as
-            # undeliverable to.
+        except client.exceptions.AccountSendingPausedException as exc:
+            # Happens when the account gets disabled. We shouldn't be retrying this
+            logger.warning("SES Account Paused", exc_info=exc, extra={"trace": True})
+            return False
+        except client.exceptions.MessageRejected as exc:
+            # Message got rejected by SES.
             logger.warning(
-                'Attempted to email a blacklisted user: %s' % recipients,
+                "Message intended for %s got rejected by AWS" % recipients,
                 exc_info=exc,
-                extra={'trace': True}
+                extra={"trace": True},
             )
             return False
-        except SESDomainEndsWithDotError, exc:
-            # Domains ending in a dot are simply invalid.
-            logger.warning(
-                'Invalid recipient, ending in dot: %s' % recipients,
+        except client.exceptions.BaseClientException as exc:
+            logger.error(
+                "General SES Exception occured while trying to send to %s" % recipients,
                 exc_info=exc,
-                extra={'trace': True}
+                extra={"trace": True},
             )
             return False
-        except SESLocalAddressCharacterError, exc:
-            # Invalid character, usually in the sender "name".
-            logger.warning(
-                'Local address contains control or whitespace: %s' % recipients,
-                exc_info=exc,
-                extra={'trace': True}
-            )
-            return False
-        except SESIllegalAddressError, exc:
-            # A clearly mal-formed address.
-            logger.warning(
-                'Illegal address: %s' % recipients,
-                exc_info=exc,
-                extra={'trace': True}
-            )
-            return False
-        except Exception, exc:
+        except Exception as exc:
             # Something else happened that we haven't explicitly forbade
             # retry attempts for.
-            #noinspection PyUnresolvedReferences
             logger.error(
-                'Something went wrong; retrying: %s' % recipients,
+                "Something went wrong; retrying: %s" % recipients,
                 exc_info=exc,
-                extra={'trace': True}
+                extra={"trace": True},
             )
             self.retry(exc=exc)
         else:
-            logger.info('An email has been successfully sent: %s' % recipients)
+            logger.info("An email has been successfully sent: %s" % recipients)
 
         # We shouldn't ever block long enough to see this, but here it is
         # just in case (for debugging?).
         return True
 
-    def _open_ses_conn(self):
+    def _get_boto_ses_client(self):
         """
         Create a connection to the AWS API server. This can be reused for
         sending multiple emails.
         """
-        if self.connection:
-            return
-
-        self.connection = get_boto_ses_connection()
+        if not self._client:
+            self._client = get_boto_ses_client()
+        return self._client

--- a/seacucumber/util.py
+++ b/seacucumber/util.py
@@ -2,52 +2,54 @@
 Various utility functions.
 """
 
+import boto3
 from django.conf import settings
-import boto.ses
+
 
 # dkim isn't required, but we'll use it if we have it.
 try:
     import dkim
+
     HAS_DKIM = True
 except ImportError:
     HAS_DKIM = False
 
 DKIM_DOMAIN = getattr(settings, "DKIM_DOMAIN", None)
-DKIM_PRIVATE_KEY = getattr(settings, 'DKIM_PRIVATE_KEY', None)
-DKIM_SELECTOR = getattr(settings, 'DKIM_SELECTOR', 'ses')
-DKIM_HEADERS = getattr(settings, 'DKIM_HEADERS', ('From', 'To', 'Cc', 'Subject'))
+DKIM_PRIVATE_KEY = getattr(settings, "DKIM_PRIVATE_KEY", None)
+DKIM_SELECTOR = getattr(settings, "DKIM_SELECTOR", "ses")
+DKIM_HEADERS = getattr(settings, "DKIM_HEADERS", ("From", "To", "Cc", "Subject"))
 
 
-def get_boto_ses_connection():
+def get_boto_ses_client():
     """
     Shortcut for instantiating and returning a boto SESConnection object.
 
-    :rtype: boto.ses.SESConnection
-    :returns: A boto SESConnection object, from which email sending is done.
+    :rtype: boto3.session.Session.client
+    :returns: A boto3 session client object, from which email sending is done.
     """
 
     access_key_id = getattr(
-        settings, 'CUCUMBER_SES_ACCESS_KEY_ID',
-        getattr(settings, 'AWS_ACCESS_KEY_ID', None))
+        settings,
+        "CUCUMBER_SES_ACCESS_KEY_ID",
+        getattr(settings, "AWS_ACCESS_KEY_ID", None),
+    )
     access_key = getattr(
-        settings, 'CUCUMBER_SES_SECRET_ACCESS_KEY',
-        getattr(settings, 'AWS_SECRET_ACCESS_KEY', None))
+        settings,
+        "CUCUMBER_SES_SECRET_ACCESS_KEY",
+        getattr(settings, "AWS_SECRET_ACCESS_KEY", None),
+    )
     region_name = getattr(
-        settings, 'CUCUMBER_SES_REGION_NAME',
-        getattr(settings, 'AWS_SES_REGION_NAME', None))
-    
-    if region_name != None:
-        return boto.ses.connect_to_region(
-            region_name,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=access_key,
-        )
-    else:
-        return boto.connect_ses(
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=access_key,
-        )
-        
+        settings,
+        "CUCUMBER_SES_REGION_NAME",
+        getattr(settings, "AWS_SES_REGION_NAME", None),
+    )
+
+    return boto3.client(
+        "ses",
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=access_key,
+        region_name=region_name,
+    )
 
 
 def dkim_sign(message):
@@ -66,5 +68,6 @@ def dkim_sign(message):
         DKIM_SELECTOR,
         DKIM_DOMAIN,
         DKIM_PRIVATE_KEY,
-        include_headers=DKIM_HEADERS)
+        include_headers=DKIM_HEADERS,
+    )
     return sig + message

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,37 @@
 from setuptools import setup
 
-DESCRIPTION = "A Django email backend for Amazon Simple Email Service, backed by celery."
 
-LONG_DESCRIPTION = open('README.rst').read()
+DESCRIPTION = (
+    "A Django email backend for Amazon Simple Email Service, backed by celery."
+)
+
+LONG_DESCRIPTION = open("README.rst").read()
 
 CLASSIFIERS = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'Framework :: Django',
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: Django",
 ]
 
 setup(
-    name='seacucumber',
-    version='1.5.2',
+    name="seacucumber",
+    version="1.6.1",
     packages=[
-        'seacucumber',
-        'seacucumber.management',
-        'seacucumber.management.commands',
+        "seacucumber",
+        "seacucumber.management",
+        "seacucumber.management.commands",
     ],
-    author='Gregory Taylor',
-    author_email='gtaylor@duointeractive.com',
-    url='https://github.com/duointeractive/sea-cucumber/',
-    license='MIT',
+    author="Gregory Taylor",
+    author_email="gtaylor@duointeractive.com",
+    url="https://github.com/duointeractive/sea-cucumber/",
+    license="MIT",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    platforms=['any'],
+    platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=['boto>=2.25.0', 'celery'],
+    install_requires=["boto3", "celery"],
 )

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=["any"],
     classifiers=CLASSIFIERS,
-    install_requires=["boto3", "celery"],
+    install_requires=["boto3", "celery", "django"],
 )


### PR DESCRIPTION
Come September, Amazon is discontinuing sigv3 for SES. Meaning, boto will stop working for SES, so everything needs to be moved to boto3, especially libraries and projects using ses through Boto.

This PR does a bit of a refresh to sea-cucumber. Tested on python3, django3 and rewritten with boto3 it should be good for another several years now.

Python compatibility - 2.7 through 3.8
Django compatibility - 1.6 (yes, 1.6) through 3
Tested with celery 3.5 as well as 4.4.1
